### PR TITLE
add netflow v9 flow template type 89 "FORWARDING STATUS"

### DIFF
--- a/lib/fluent/plugin/netflow.yaml
+++ b/lib/fluent/plugin/netflow.yaml
@@ -213,3 +213,6 @@
 83:
 - :string
 - :if_desc
+89:
+- :uint8
+- :forwarding_status


### PR DESCRIPTION
In IOS-XR (Cisco ASR9000 series), template contains type 89 "FORWARDING STATUS".
Flow data is ignored, because template  is not registered.
This pullreq make enable to parse the template contains the type.
