### PR TITLE
fix macaddr bug

### DIFF
--- a/lib/fluent/plugin/netflow.yaml
+++ b/lib/fluent/plugin/netflow.yaml
@@ -164,10 +164,10 @@
 - :dst_tos
 56:
 - :mac_addr
-- :in_src_max
+- :in_src_mac
 57:
 - :mac_addr
-- :out_dst_max
+- :out_dst_mac
 58:
 - :uint16
 - :src_vlan

--- a/lib/fluent/plugin/parser_netflow.rb
+++ b/lib/fluent/plugin/parser_netflow.rb
@@ -278,7 +278,7 @@ module Fluent
         end
 
         def get
-          self.bytes.collect { |byte| byte.to_s(16) }.join(":")
+          self.bytes.collect { |byte| byte.value.to_s(16).rjust(2,'0') }.join(":")
         end
       end
 


### PR DESCRIPTION
I got "wrong number of arguments (1 for 0)" error messages with netflowv9 from ASR9K, and found the bug.
- `value` method should be used to get internal object
- fixed some typos in netflow.yaml as well
