### PR TITLE
Fix type mismatch in receive_data, BinData::UInt32be -> Integer.

### DIFF
--- a/lib/fluent/plugin/in_netflow.rb
+++ b/lib/fluent/plugin/in_netflow.rb
@@ -68,7 +68,7 @@ module Fluent::Plugin
         end
 
         record['host'] = host
-        router.emit(@tag, time, record)
+        router.emit(@tag, Integer(time), record)
       }
     rescue => e
       log.warn "unexpected error on parsing", data: data.dump, error_class: e.class, error: e.message


### PR DESCRIPTION
When this plugin parsed Netflow v9, the error occurred.
That was "time must be a Fluent::EventTime (or Integer): BinData::Uint32be".
Through investigation, I found that the error was came from `router.emit(@tag, time, record)`.
So I fixed this, time -> Integer(time).